### PR TITLE
Added unit tests, replaced String for &str and removed println!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totp-rs"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Cleo Rebert <cleo.rebert@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library permits the creation of 2FA authentification tokens per TOTP, the v
 Add it to your `Cargo.toml`:
 ```toml
 [dependencies]
-totp-rs = "~0.3"
+totp-rs = "~0.4"
 ```
 You can then do something like:
 ```Rust
@@ -35,7 +35,7 @@ println!("{}", token);
 Add it to your `Cargo.toml`:
 ```toml
 [dependencies.totp-rs]
-version = "~0.3"
+version = "~0.4"
 features = ["qr"]
 ```
 You can then do something like:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ You can then do something like:
 use std::time::SystemTime;
 use totp_rs::{Algorithm, TOTP};
 
-let username = "example".to_owned();
 let totp = TOTP::new(
     Algorithm::SHA1,
     6,
@@ -25,7 +24,7 @@ let totp = TOTP::new(
 let time = SystemTime::now()
     .duration_since(SystemTime::UNIX_EPOCH).unwrap()
     .as_secs();
-let url = totp.get_url(format!("account:{}", username), "my-org.com".to_owned());
+let url = totp.get_url("user@example.com", "my-org.com");
 println!("{}", url);
 let token = totp.generate(time);
 println!("{}", token);
@@ -43,7 +42,6 @@ You can then do something like:
 ```Rust
 use totp_rs::{Algorithm, TOTP};
 
-let username = "example".to_owned();
 let totp = TOTP::new(
     Algorithm::SHA1,
     6,
@@ -51,6 +49,6 @@ let totp = TOTP::new(
     30,
     "supersecret".to_owned().into_bytes(),
 );
-let code = totp.get_qr(format!("account:{}", username), "my-org.com".to_owned())?;
+let code = totp.get_qr("user@example.com", "my-org.com")?;
 println!("{}", code);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! use std::time::SystemTime;
 //! use totp_rs::{Algorithm, TOTP};
 //! 
-//! let username = "example";
 //! let totp = TOTP::new(
 //!     Algorithm::SHA1,
 //!     6,
@@ -17,7 +16,7 @@
 //! let time = SystemTime::now()
 //!     .duration_since(SystemTime::UNIX_EPOCH).unwrap()
 //!     .as_secs();
-//! let url = totp.get_url(username, "my-org.com");
+//! let url = totp.get_url("user@example.com", "my-org.com");
 //! println!("{}", url);
 //! let token = totp.generate(time);
 //! println!("{}", token);
@@ -26,7 +25,6 @@
 //! ```rust
 //! use totp_rs::{Algorithm, TOTP};
 //!
-//! let username = "example";
 //! let totp = TOTP::new(
 //!     Algorithm::SHA1,
 //!     6,
@@ -34,7 +32,7 @@
 //!     30,
 //!     "supersecret".to_owned().into_bytes(),
 //! );
-//! let code = totp.get_qr(username, "my-org.com").unwrap();
+//! let code = totp.get_qr("user@example.com", "my-org.com").unwrap();
 //! println!("{}", code);
 //! ```
 


### PR DESCRIPTION
Hi, I changed a few `String`s to `&str` to remove some unnecessary allocations. I saw there was a println! in the check-method that you probably use for testing. In my production code these println!'s also popped up. I removed it and added automated tests. These tests can be run with `cargo test --features qr`.

I also exposed the `get_secret_base32` method, which was already implemented by you. This can be used if you want to let a user copy the secret in a GUI, instead of scanning the QR.

Unfortunately this code is not compatible with 0.3.x since because in some places `Strings` were replaced by `&str`. That is why this would be a 0.4.0 release. But it is easy to change existing code to this '0.4.0' version by sending a reference to a `String` type as an argument. This will internally be transformed to `&str`:

0.3.x:
```rust
let user: String = format!("account:{}", username);
let organization: String = "my-org.com".to_owned();
let url = totp.get_url(user, organization);
```

0.4.0:
```rust
let user: String = format!("account:{}", username);
let organization: String = "my-org.com".to_owned();
let url = totp.get_url(&user, &organization);
```

But this is also possible now in 0.4.0: 
```rust
let url = totp.get_url("user@example.com", "my-org.com");
```