### PR TITLE
Remove some unnecessary to_vec calls in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This library permits the creation of 2FA authentification tokens per TOTP, the v
 ## Features
 ---
 ### qr
-With optionnal feature "qr", you can use it to generate a base64 png qrcode
+With optional feature "qr", you can use it to generate a base64 png qrcode
 ### serde_support
-With optionnal feature "serde_support", library-defined types will be Deserialize-able and Serialize-able
+With optional feature "serde_support", library-defined types will be Deserialize-able and Serialize-able
 
 ## How to use
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
 
     /// Will sign the given timestamp
     pub fn sign(&self, time: u64) -> Vec<u8> {
-        let ctr = (time / self.step).to_be_bytes().to_vec();
+        let ctr = (time / self.step).to_be_bytes();
         match self.algorithm {
             Algorithm::SHA1 => {
                 let mut mac = HmacSha1::new_varkey(self.secret.as_ref()).expect("no key");
@@ -116,7 +116,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
     pub fn generate(&self, time: u64) -> String {
         let result: &[u8] = &self.sign(time);
         let offset = (result[19] & 15) as usize;
-        let mut rdr = Cursor::new(result[offset..offset + 4].to_vec());
+        let mut rdr = Cursor::new(&result[offset..offset + 4]);
         let result = rdr.read_u32::<BigEndian>().unwrap() & 0x7fff_ffff;
         format!(
             "{1:00$}",
@@ -177,7 +177,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
         let size: u32 = ((code.width() + 8) * 8) as u32;
         let encoder = image::png::PNGEncoder::new(&mut vec);
         encoder.encode(
-            &code.render::<Luma<u8>>().build().to_vec(),
+            code.render::<Luma<u8>>().build().as_ref(),
             size,
             size,
             image::ColorType::L8,


### PR DESCRIPTION
Avoids some unnecessary `to_vec` calls when a `&[u8]` is enough.
Also fixes a small typo.