### PR TITLE
V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target
 Cargo.lock
 .vscode/settings.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totp-rs"
-version = "1.4.0"
+version = "2.0.0"
 authors = ["Cleo Rebert <cleo.rebert@gmail.com>"]
 edition = "2021"
 readme = "README.md"
@@ -12,13 +12,12 @@ keywords = ["authentication", "2fa", "totp", "hmac", "otp"]
 categories = ["authentication", "web-programming"]
 
 [package.metadata.docs.rs]
-features = [ "qr", "serde_support", "otpauth" ]
+features = [ "qr", "serde_support" ]
 
 [features]
-default = ["otpauth"]
+default = []
 qr = ["qrcodegen", "image", "base64"]
 serde_support = ["serde"]
-otpauth = ["url"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -26,8 +25,8 @@ sha2 = "~0.10.2"
 sha-1 = "~0.10.0"
 hmac = "~0.12.1"
 base32 = "~0.4"
+url = "2.2.2"
 constant_time_eq = "~0.2.1"
 qrcodegen = { version = "~1.8", optional = true }
 image = { version = "~0.24.2", features = ["png"], optional = true, default-features = false}
 base64 = { version = "~0.13", optional = true }
-url = { version = "2.2.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["authentication", "web-programming"]
 features = [ "qr", "serde_support", "otpauth" ]
 
 [features]
-default = []
+default = ["otpauth"]
 qr = ["qrcodegen", "image", "base64"]
 serde_support = ["serde"]
 otpauth = ["url"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ features = [ "qr", "serde_support" ]
 
 [features]
 default = []
-qr = ["qrcodegen", "image", "base64"]
+otpauth = ["url"]
+qr = ["qrcodegen", "image", "base64", "otpauth"]
 serde_support = ["serde"]
 
 [dependencies]
@@ -25,7 +26,7 @@ sha2 = "~0.10.2"
 sha-1 = "~0.10.0"
 hmac = "~0.12.1"
 base32 = "~0.4"
-url = "2.2.2"
+url = { version = "2.2.2", optional = true } 
 constant_time_eq = "~0.2.1"
 qrcodegen = { version = "~1.8", optional = true }
 image = { version = "~0.24.2", features = ["png"], optional = true, default-features = false}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Be aware that some authenticator apps will accept the `SHA256` and `SHA512` algo
 ## Features
 ---
 ### qr
-With optional feature "qr", you can use it to generate a base64 png qrcode
+With optional feature "qr", you can use it to generate a base64 png qrcode. This will enable feature `otpauth`
+### otpauth
+With optional feature "otpauth", support parsing the TOTP parameters from an `otpauth` URL, and generating an `otpauth` URL
 ### serde_support
-With optional feature "serde_support", library-defined types will be Deserialize-able and Serialize-able
+With optional feature "serde_support", library-defined types `TOTP` and `Algorithm` and will be Deserialize-able and Serialize-able
 
 ## How to use
 ---
@@ -36,8 +38,6 @@ fn main() {
         Some("Github".to_string()),
         "constantoine@github.com".to_string(),
     ).unwrap();
-    let url = totp.get_url();
-    println!("{}", url);
     let token = totp.generate_current().unwrap();
     println!("{}", token);   
 }
@@ -82,8 +82,9 @@ features = ["serde_support"]
 
 Add it to your `Cargo.toml`:
 ```toml
-[dependencies]
-totp-rs = "^2.0"
+[dependencies.totp-rs]
+version = "^2.0"
+features = ["otpauth"]
 ```
 You can then do something like:
 ```Rust

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # totp-rs
 ![Build Status](https://github.com/constantoine/totp-rs/workflows/Rust/badge.svg) [![docs](https://docs.rs/totp-rs/badge.svg)](https://docs.rs/totp-rs) [![](https://img.shields.io/crates/v/totp-rs.svg)](https://crates.io/crates/totp-rs) [![codecov](https://codecov.io/gh/constantoine/totp-rs/branch/master/graph/badge.svg?token=Q50RAIFVWZ)](https://codecov.io/gh/constantoine/totp-rs) [![cargo-audit](https://github.com/constantoine/totp-rs/actions/workflows/security.yml/badge.svg)](https://github.com/constantoine/totp-rs/actions/workflows/security.yml)
 
-This library permits the creation of 2FA authentification tokens per TOTP, the verification of said tokens, with configurable time skew, validity time of each token, algorithm and number of digits! Default features are kept as lightweight as possible to ensure small binaries and short compilation time
+This library permits the creation of 2FA authentification tokens per TOTP, the verification of said tokens, with configurable time skew, validity time of each token, algorithm and number of digits! Default features are kept as lightweight as possible to ensure small binaries and short compilation time.
+
+It now supports parsing [otpauth URLs](https://github.com/google/google-authenticator/wiki/Key-Uri-Format) into a totp object, with sane default values.
 
 Be aware that some authenticator apps will accept the `SHA256` and `SHA512` algorithms but silently fallback to `SHA1` which will make the `check()` function fail due to mismatched algorithms.
 
@@ -12,33 +14,33 @@ With optional feature "qr", you can use it to generate a base64 png qrcode
 ### serde_support
 With optional feature "serde_support", library-defined types will be Deserialize-able and Serialize-able
 
-### otpauth
-
-With optional feature "otpauth", Support to parse the TOTP parameter from `otpauth` URL
-
 ## How to use
 ---
 Add it to your `Cargo.toml`:
 ```toml
 [dependencies]
-totp-rs = "~1.4"
+totp-rs = "^2.0"
 ```
 You can then do something like:
 ```Rust
 use std::time::SystemTime;
 use totp_rs::{Algorithm, TOTP};
 
-let totp = TOTP::new(
-    Algorithm::SHA1,
-    6,
-    1,
-    30,
-    "supersecret",
-);
-let url = totp.get_url("user@example.com", "my-org.com");
-println!("{}", url);
-let token = totp.generate_current().unwrap();
-println!("{}", token);
+fn main() {
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        "supersecret",
+        Some("Github".to_string()),
+        "constantoine@github.com".to_string(),
+    ).unwrap();
+    let url = totp.get_url();
+    println!("{}", url);
+    let token = totp.generate_current().unwrap();
+    println!("{}", token);   
+}
 ```
 
 ### With qrcode generation
@@ -46,29 +48,33 @@ println!("{}", token);
 Add it to your `Cargo.toml`:
 ```toml
 [dependencies.totp-rs]
-version = "~1.4"
+version = "^2.0"
 features = ["qr"]
 ```
 You can then do something like:
 ```Rust
 use totp_rs::{Algorithm, TOTP};
 
-let totp = TOTP::new(
-    Algorithm::SHA1,
-    6,
-    1,
-    30,
-    "supersecret",
-);
-let code = totp.get_qr("user@example.com", "my-org.com")?;
-println!("{}", code);
+fn main() {
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        "supersecret",
+        Some("Github".to_string()),
+        "constantoine@github.com".to_string(),
+    ).unwrap();
+    let code = totp.get_qr("user@example.com", "my-org.com")?;
+    println!("{}", code);   
+}
 ```
 
 ### With serde support
 Add it to your `Cargo.toml`:
 ```toml
 [dependencies.totp-rs]
-version = "~1.4"
+version = "^2.0"
 features = ["serde_support"]
 ```
 
@@ -76,15 +82,16 @@ features = ["serde_support"]
 
 Add it to your `Cargo.toml`:
 ```toml
-[dependencies.totp-rs]
-version = "~1.4"
-features = ["otpauth"]
+[dependencies]
+totp-rs = "^2.0"
 ```
 You can then do something like:
 ```Rust
 use totp_rs::TOTP;
 
-let otpauth = "otpauth://totp/GitHub:test?secret=ABC&issuer=GitHub";
-let totp = TOTP::from_url(otpauth).unwrap();
-println!("{}", totp.generate_current().unwrap());
+fn main() {
+    let otpauth = "otpauth://totp/GitHub:constantoine@github.com?secret=ABC&issuer=GitHub";
+    let totp = TOTP::from_url(otpauth).unwrap();
+    println!("{}", totp.generate_current().unwrap());
+}
 ```


### PR DESCRIPTION
### What changed
- `issuer` and `account_name` are now members of TOTP, and thus are not used anymore as function parameters for methods
- `from_url()` now extracts issuer and label
- Method `get_url()` now needs `otpauth` feature
- Method `get_url()` now produces more correct urls
- Methods `next_step(time: u64)` and `next_step_current` will return the timestamp of the next step's start
- Feature `qr` enables feature `otpauth` 

### Comments/ideas appreciated!