### PR TITLE
Implement Error trait for TotpUrlError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ constant_time_eq = "~0.2.1"
 qrcodegen = { version = "~1.8", optional = true }
 image = { version = "~0.24.2", features = ["png"], optional = true, default-features = false}
 base64 = { version = "~0.13", optional = true }
+thiserror = "~1.0"


### PR DESCRIPTION
Added dependency `thiserror` to implement the error trait for the TotpUrlError enum, so it can be used as a regular error, for example with `anyhow`. Also included the invalid value in the enums to make it clearer why there was an error.

Let me know if you want me to change anything else in the pull request, there were some minor things clippy noticed.