### PR TITLE
Rfc6238 struct

### DIFF
--- a/examples/rfc-6238.rs
+++ b/examples/rfc-6238.rs
@@ -1,0 +1,17 @@
+use totp_rs::{Rfc6238, TOTP};
+
+fn main () {
+    let mut rfc = Rfc6238::with_defaults(
+        "totp-sercret-123"
+    ).unwrap();
+
+    // optional, set digits, issuer, account_name
+    rfc.digits(8).unwrap();
+    rfc.issuer("issuer".to_string());
+    rfc.account_name("user-account".to_string());
+
+    // create a TOTP from rfc
+    let totp = TOTP::from_rfc6238(rfc).unwrap();
+    let code = totp.generate_current().unwrap();
+    println!("code: {}", code);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,15 @@ pub enum TotpUrlError {
     AccountName,
 }
 
+impl From<Rfc6238Error> for TotpUrlError {
+    fn from(e: Rfc6238Error) -> Self {
+        match e {
+            Rfc6238Error::InvalidDigits => TotpUrlError::Digits,
+            Rfc6238Error::SecretTooSmall => TotpUrlError::Secret,
+        }
+    }
+}
+
 /// TOTP holds informations as to how to generate an auth code and validate it. Its [secret](struct.TOTP.html#structfield.secret) field is sensitive data, treat it accordingly
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
@@ -181,10 +190,14 @@ impl <T: AsRef<[u8]>> PartialEq for TOTP<T> {
 impl<T: AsRef<[u8]>> TOTP<T> {
     /// Will create a new instance of TOTP with given parameters. See [the doc](struct.TOTP.html#fields) for reference as to how to choose those values
     ///
+    /// # Description
+    /// * `digits`: MUST be between 6 & 8
+    ///
     /// # Errors
     ///
     /// Will return an error in case issuer or label contain the character ':'
     pub fn new(algorithm: Algorithm, digits: usize, skew: u8, step: u64, secret: T, issuer: Option<String>, account_name: String) -> Result<TOTP<T>, TotpUrlError> {
+        crate::rfc::assert_digits(&digits)?;
         if issuer.is_some() && issuer.as_ref().unwrap().contains(':') {
             return Err(TotpUrlError::Issuer);
         }
@@ -340,12 +353,6 @@ impl<T: AsRef<[u8]>> TOTP<T> {
             }
         }
 
-        if issuer.is_some() && issuer.as_ref().unwrap().contains(':') {
-            return Err(TotpUrlError::Issuer);
-        }
-        if account_name.contains(':') {
-            return Err(TotpUrlError::AccountName);
-        }
         if secret.is_empty() {
             return Err(TotpUrlError::Secret);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This library permits the creation of 2FA authentification tokens per TOTP, the verification of said tokens, with configurable time skew, validity time of each token, algorithm and number of digits! Default features are kept as low-dependency as possible to ensure small binaries and short compilation time
 //!
-//! Be aware that some authenticator apps will accept the `SHA256` 
-//! and `SHA512` algorithms but silently fallback to `SHA1` which will 
+//! Be aware that some authenticator apps will accept the `SHA256`
+//! and `SHA512` algorithms but silently fallback to `SHA1` which will
 //! make the `check()` function fail due to mismatched algorithms.
 //!
 //! Use the `SHA1` algorithm to avoid this problem.
@@ -44,6 +44,10 @@
 //! println!("{}", code);
 //! # }
 //! ```
+
+mod rfc;
+
+pub use rfc::{Rfc6238, Rfc6238Error};
 
 use constant_time_eq::constant_time_eq;
 
@@ -178,7 +182,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
     /// Will create a new instance of TOTP with given parameters. See [the doc](struct.TOTP.html#fields) for reference as to how to choose those values
     ///
     /// # Errors
-    /// 
+    ///
     /// Will return an error in case issuer or label contain the character ':'
     pub fn new(algorithm: Algorithm, digits: usize, skew: u8, step: u64, secret: T, issuer: Option<String>, account_name: String) -> Result<TOTP<T>, TotpUrlError> {
         if issuer.is_some() && issuer.as_ref().unwrap().contains(':') {
@@ -196,6 +200,15 @@ impl<T: AsRef<[u8]>> TOTP<T> {
             issuer,
             account_name,
         })
+    }
+
+    /// Will create a new instance of TOTP from the given [Rfc6238](struct.Rfc6238.html) struct
+    ///
+    /// # Errors
+    ///
+    /// Will return an error in case issuer or label contain the character ':'
+    pub fn from_rfc6238(rfc: Rfc6238<T>) -> Result<TOTP<T>, TotpUrlError> {
+        TOTP::try_from(rfc)
     }
 
     /// Will sign the given timestamp
@@ -244,7 +257,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
         let basestep = time / self.step - (self.skew as u64);
         for i in 0..self.skew * 2 + 1 {
             let step_time = (basestep + (i as u64)) * (self.step as u64);
-            
+
             if constant_time_eq(self.generate(step_time).as_bytes(), token.as_bytes()) {
                 return true;
             }
@@ -265,7 +278,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
             self.secret.as_ref(),
         )
     }
-    
+
     /// Generate a TOTP from the standard otpauth URL
     #[cfg(feature = "otpauth")]
     pub fn from_url<S: AsRef<str>>(url: S) -> Result<TOTP<Vec<u8>>, TotpUrlError> {
@@ -276,7 +289,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
         if url.host() != Some(Host::Domain("totp")) {
             return Err(TotpUrlError::Host);
         }
-        
+
         let mut algorithm = Algorithm::SHA1;
         let mut digits = 6;
         let mut step = 30;
@@ -292,7 +305,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
         } else {
             account_name = path.to_owned();
         }
-        
+
         account_name = urlencoding::decode(account_name.as_str()).map_err(|_| TotpUrlError::AccountName)?.to_string();
 
         for (key, value) in url.query_pairs() {
@@ -341,7 +354,7 @@ impl<T: AsRef<[u8]>> TOTP<T> {
     }
 
     /// Will generate a standard URL used to automatically add TOTP auths. Usually used with qr codes
-    /// 
+    ///
     /// Label and issuer will be URL-encoded if needed be
     /// Secret will be base 32'd without padding, as per RFC.
     #[cfg(feature = "otpauth")]
@@ -383,12 +396,12 @@ impl<T: AsRef<[u8]>> TOTP<T> {
         let mut vec = Vec::new();
         let qr = qrcodegen::QrCode::encode_text(&url, qrcodegen::QrCodeEcc::Medium)?;
         let size = qr.size() as u32;
-        
+
         // "+ 8 * 8" is here to add padding (the white border around the QRCode)
-        // As some QRCode readers don't work without padding 
+        // As some QRCode readers don't work without padding
         let image_size = size * 8 + 8 * 8;
         let mut canvas = image::GrayImage::new(image_size, image_size);
-        
+
         // Draw the border
         for x in 0..image_size {
             for y in 0..image_size {
@@ -405,12 +418,12 @@ impl<T: AsRef<[u8]>> TOTP<T> {
                 // This clever trick to one-line the value was achieved with advanced mathematics
                 // And deep understanding of Boolean algebra.
                 let val = !qr.get_module(x_qr as i32, y_qr as i32) as u8 * 255;
-                
+
                 // Multiply coordinates by width of pixels
                 // And take into account the 8*4 padding on top and left side
                 let x_start = x_qr * 8 + 8*4;
                 let y_start = y_qr * 8 + 8*4;
-                
+
                 // Draw a 8-pixels-wide square
                 for x_img in x_start..x_start + 8 {
                     for y_img in y_start..y_start + 8 {

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for Rfc6238Error {
     }
 }
 
-fn assert_digits(digits: &usize) -> Result<(), Rfc6238Error> {
+pub fn assert_digits(digits: &usize) -> Result<(), Rfc6238Error> {
     if !(&6..=&8).contains(&digits) {
         Err(Rfc6238Error::InvalidDigits)
     } else {

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -2,6 +2,9 @@ use crate::Algorithm;
 use crate::TotpUrlError;
 use crate::TOTP;
 
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 /// Data is not compliant to [rfc-6238](https://tools.ietf.org/html/rfc6238)
 #[derive(Debug, Eq, PartialEq)]
 pub enum Rfc6238Error {

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -1,0 +1,258 @@
+use crate::Algorithm;
+use crate::TotpUrlError;
+use crate::TOTP;
+
+/// Data is not compliant to [rfc-6238](https://tools.ietf.org/html/rfc6238)
+#[derive(Debug, Eq, PartialEq)]
+pub enum Rfc6238Error {
+    /// Implementations MUST extract a 6-digit code at a minimum and possibly 7 and 8-digit code
+    InvalidDigits,
+    /// The length of the shared secret MUST be at least 128 bits
+    SecretTooSmall,
+}
+
+impl std::fmt::Display for Rfc6238Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Rfc6238Error::InvalidDigits => write!(
+                f,
+                "Implementations MUST extract a 6-digit code at a minimum and possibly 7 and 8-digit code"
+            ),
+            Rfc6238Error::SecretTooSmall => write!(
+                f,
+                "The length of the shared secret MUST be at least 128 bits"
+            ),
+        }
+    }
+}
+
+fn assert_digits(digits: &usize) -> Result<(), Rfc6238Error> {
+    if digits < &6 || digits > &8 {
+        Err(Rfc6238Error::InvalidDigits)
+    } else {
+        Ok(())
+    }
+}
+
+/// [rfc-6238](https://tools.ietf.org/html/rfc6238) compliant set of options to create a [TOTP](struct.TOTP.html)
+///
+/// # Example
+/// ```
+/// use totp_rs::{Rfc6238, TOTP};
+///
+/// let mut rfc = Rfc6238::with_defaults(
+///     "totp-sercret-123"
+/// ).unwrap();
+///
+/// // optional, set digits, issuer, account_name
+/// rfc.digits(8).unwrap();
+/// rfc.issuer("issuer".to_string());
+/// rfc.account_name("user-account".to_string());
+///
+/// let totp = TOTP::from_rfc6238(rfc).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+pub struct Rfc6238<T = Vec<u8>> {
+    /// SHA-1
+    algorithm: Algorithm,
+    /// The number of digits composing the auth code. Per [rfc-4226](https://tools.ietf.org/html/rfc4226#section-5.3), this can oscilate between 6 and 8 digits
+    digits: usize,
+    /// The recommended value per [rfc-6238](https://tools.ietf.org/html/rfc6238#section-5.2) is 1.
+    skew: u8,
+    /// The recommended value per [rfc-6238](https://tools.ietf.org/html/rfc6238#section-5.2) is 30 seconds
+    step: u64,
+    /// As per [rfc-4226](https://tools.ietf.org/html/rfc4226#section-4) the secret should come from a strong source, most likely a CSPRNG. It should be at least 128 bits, but 160 are recommended
+    secret: T,
+    /// The "Github" part of "Github:constantoine@github.com". Must not contain a colon `:`
+    /// For example, the name of your service/website.
+    /// Not mandatory, but strongly recommended!
+    issuer: Option<String>,
+    /// The "constantoine@github.com" part of "Github:constantoine@github.com". Must not contain a colon `:`
+    /// For example, the name of your user's account.
+    account_name: String,
+}
+
+impl<T: AsRef<[u8]>> Rfc6238<T> {
+    /// Create an [rfc-6238](https://tools.ietf.org/html/rfc6238) compliant set of options that can be turned into a [TOTP](struct.TOTP.html)
+    ///
+    /// # Errors
+    ///
+    /// will return a [Rfc6238Error](enum.Rfc6238Error.html) when
+    /// - `digits` is lower than 6 or higher than 8
+    /// - `secret` is smaller than 128 bits (16 characters)
+    pub fn new(
+        digits: usize,
+        secret: T,
+        issuer: Option<String>,
+        account_name: String,
+    ) -> Result<Rfc6238<T>, Rfc6238Error> {
+        assert_digits(&digits)?;
+        if secret.as_ref().len() < 16 {
+            Err(Rfc6238Error::SecretTooSmall)
+        } else {
+            Ok(Rfc6238 {
+                algorithm: Algorithm::SHA1,
+                digits,
+                skew: 1,
+                step: 30,
+                secret,
+                issuer,
+                account_name,
+            })
+        }
+    }
+
+    /// Create an [rfc-6238](https://tools.ietf.org/html/rfc6238) compliant set of options that can be turned into a [TOTP](struct.TOTP.html),
+    /// with a default value of 6 for `digits`, None `issuer` and an empty account
+    ///
+    /// # Errors
+    ///
+    /// will return a [Rfc6238Error](enum.Rfc6238Error.html) when
+    /// - `digits` is lower than 6 or higher than 8
+    /// - `secret` is smaller than 128 bits (16 characters)
+    pub fn with_defaults(secret: T) -> Result<Rfc6238<T>, Rfc6238Error> {
+        Rfc6238::new(6, secret, None, "".to_string())
+    }
+
+    /// Set the `digits`
+    pub fn digits(&mut self, value:usize) -> Result<(), Rfc6238Error> {
+        assert_digits(&value)?;
+        self.digits = value;
+        Ok(())
+    }
+
+    /// Set the `issuer`
+    pub fn issuer(&mut self, value: String) {
+        self.issuer = Some(value);
+    }
+
+    /// Seet the `account_name`
+    pub fn account_name(&mut self, value: String) {
+        self.account_name = value;
+    }
+}
+
+impl<T: AsRef<[u8]>> TryFrom<Rfc6238<T>> for TOTP<T> {
+    type Error = TotpUrlError;
+
+    /// Try to create a [TOTP](struct.TOTP.html) from a [Rfc6238](struct.Rfc6238.html) config
+    fn try_from(rfc: Rfc6238<T>) -> Result<Self, Self::Error> {
+        TOTP::new(
+            rfc.algorithm,
+            rfc.digits,
+            rfc.skew,
+            rfc.step,
+            rfc.secret,
+            rfc.issuer,
+            rfc.account_name,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::TotpUrlError;
+
+    use super::{Rfc6238, Rfc6238Error, TOTP};
+
+    const GOOD_SECRET: &str = "01234567890123456789";
+    const ISSUER: Option<&str> = None;
+    const ACCOUNT: &str = "valid-account";
+    const INVALID_ACCOUNT: &str = ":invalid-account";
+
+    #[test]
+    fn new_rfc_digits() {
+        for x in 0..=20 {
+            let rfc = Rfc6238::new(
+                x,
+                GOOD_SECRET.to_string(),
+                ISSUER.map(str::to_string),
+                ACCOUNT.to_string(),
+            );
+            if x < 6 || x > 8 {
+                assert!(rfc.is_err());
+                assert_eq!(rfc.unwrap_err(), Rfc6238Error::InvalidDigits)
+            } else {
+                assert!(rfc.is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn new_rfc_secret() {
+        let mut secret = String::from("");
+        for _ in 0..=20 {
+            secret = format!("{}{}", secret, "0");
+            let rfc = Rfc6238::new(
+                6,
+                secret.clone(),
+                ISSUER.map(str::to_string),
+                ACCOUNT.to_string(),
+            );
+            let rfc_default = Rfc6238::with_defaults(secret.clone());
+            if secret.len() < 16 {
+                assert!(rfc.is_err());
+                assert_eq!(rfc.unwrap_err(), Rfc6238Error::SecretTooSmall);
+                assert!(rfc_default.is_err());
+                assert_eq!(rfc_default.unwrap_err(), Rfc6238Error::SecretTooSmall);
+            } else {
+                assert!(rfc.is_ok());
+                assert!(rfc_default.is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn rfc_to_totp_ok() {
+        let rfc = Rfc6238::new(
+            8,
+            GOOD_SECRET.to_string(),
+            ISSUER.map(str::to_string),
+            ACCOUNT.to_string(),
+        )
+        .unwrap();
+        let totp = TOTP::try_from(rfc);
+        assert!(totp.is_ok());
+        let otp = totp.unwrap();
+        assert_eq!(&otp.secret, GOOD_SECRET);
+        assert_eq!(otp.algorithm, crate::Algorithm::SHA1);
+        assert_eq!(&otp.account_name, ACCOUNT);
+        assert_eq!(otp.digits, 8);
+        assert_eq!(otp.issuer, ISSUER.map(str::to_string));
+        assert_eq!(otp.skew, 1);
+        assert_eq!(otp.step, 30)
+    }
+
+    #[test]
+    fn rfc_to_totp_fail() {
+        let rfc = Rfc6238::new(
+            8,
+            GOOD_SECRET.to_string(),
+            ISSUER.map(str::to_string),
+            INVALID_ACCOUNT.to_string(),
+        )
+        .unwrap();
+        let totp = TOTP::try_from(rfc);
+        assert!(totp.is_err());
+        assert_eq!(totp.unwrap_err(), TotpUrlError::AccountName)
+    }
+
+    #[test]
+    fn rfc_with_default_set_values() {
+        let new_account = "new-account";
+        let new_issuer = String::from("new-issuer");
+        let mut rfc = Rfc6238::with_defaults(GOOD_SECRET.to_string()).unwrap();
+        rfc.issuer(new_issuer.clone());
+        assert_eq!(rfc.issuer, Some(new_issuer));
+        rfc.account_name(new_account.to_string());
+        assert_eq!(rfc.account_name, new_account.to_string());
+        let fail = rfc.digits(4);
+        assert!(fail.is_err());
+        assert_eq!(fail.unwrap_err(), Rfc6238Error::InvalidDigits);
+        assert_eq!(rfc.digits, 6);
+        let ok = rfc.digits(8);
+        assert!(ok.is_ok());
+        assert_eq!(rfc.digits, 8)
+    }
+}

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -27,7 +27,7 @@ impl std::fmt::Display for Rfc6238Error {
 }
 
 fn assert_digits(digits: &usize) -> Result<(), Rfc6238Error> {
-    if digits < &6 || digits > &8 {
+    if !(&6..=&8).contains(&digits) {
         Err(Rfc6238Error::InvalidDigits)
     } else {
         Ok(())


### PR DESCRIPTION
## Note
- All changes should be non-breaking and opt-in.
- Example files are available to see how these changes could be used.

## Changes

### Add Rfc6238 struct

Allows easy creation of rfc-6238 compliant TOTP instance.
The struct `Rfc6238` does validate both `digits` and `secret` fields for rfc compliance:
 - `digits` must be between 6 and 8 ; 
 - `secret` must be at least 128 bits

```rust
let rfc = Rfc6238::with_defaults(
    "totp-sercret-123"
).unwrap();

// create a TOTP from rfc
let totp = TOTP::from_rfc6238(rfc).unwrap();
```