### PR TITLE
replace the sha-1 crate with sha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gen_secret = ["rand"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha2 = "~0.10.2"
-sha-1 = "~0.10.0"
+sha1 = "~0.10.5"
 hmac = "~0.12.1"
 base32 = "~0.4"
 urlencoding = { version = "^2.1.0", optional = true}


### PR DESCRIPTION
As RustCrypto have migrated to the new crate name.

Ref https://github.com/RustCrypto/hashes#crate-names