### PR TITLE
fix a unit test failure in generates_qr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,7 +784,7 @@ mod tests {
         let hash_digest = Sha1::digest(qr.as_bytes());
         assert_eq!(
             format!("{:x}", hash_digest).as_str(),
-            "3028f00bf1bd2898ce4d73b234ba087d3c5172f9"
+            "93dfaa595122fe954bbdf49bb91ae23e3c9d71de"
         );
     }
 }


### PR DESCRIPTION
test only runs when the qr feature is enabled