### PR TITLE
Support zeroize feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ otpauth = ["url", "urlencoding"]
 qr = ["qrcodegen", "image", "base64", "otpauth"]
 serde_support = ["serde"]
 gen_secret = ["rand"]
+zeroize = ["dep:zeroize"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -34,3 +35,4 @@ qrcodegen = { version = "~1.8", optional = true }
 image = { version = "~0.24.2", features = ["png"], optional = true, default-features = false}
 base64 = { version = "~0.13", optional = true }
 rand = { version = "~0.8.5", features = ["std_rng", "std"], optional = true, default-features = false }
+zeroize = { version = "1.5.7", features = ["alloc", "derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ With optional feature "otpauth", support parsing the TOTP parameters from an `ot
 With optional feature "serde_support", library-defined types `TOTP` and `Algorithm` and will be Deserialize-able and Serialize-able.
 ### gen_secret
 With optional feature "gen_secret", a secret will be generated for you to store in database.
+### zeroize
+Securely zero secret information when the TOTP struct is dropped.
 
 
 # Examples

--- a/examples/rfc-6238.rs
+++ b/examples/rfc-6238.rs
@@ -2,7 +2,7 @@ use totp_rs::{Rfc6238, TOTP};
 
 #[cfg(feature = "otpauth")]
 fn main() {
-    let mut rfc = Rfc6238::with_defaults("totp-sercret-123").unwrap();
+    let mut rfc = Rfc6238::with_defaults("totp-sercret-123".as_bytes().to_vec()).unwrap();
 
     // optional, set digits, issuer, account_name
     rfc.digits(8).unwrap();

--- a/examples/ttl.rs
+++ b/examples/ttl.rs
@@ -2,7 +2,7 @@ use totp_rs::{Algorithm, TOTP};
 
 #[cfg(not(feature = "otpauth"))]
 fn main() {
-    let totp = TOTP::new(Algorithm::SHA1, 6, 1, 30, "my-secret".to_string()).unwrap();
+    let totp = TOTP::new(Algorithm::SHA1, 6, 1, 30, "my-secret".as_bytes().to_vec()).unwrap();
 
     loop {
         println!(
@@ -22,7 +22,7 @@ fn main() {
         6,
         1,
         30,
-        "my-secret".to_string(),
+        "my-secret".as_bytes().to_vec(),
         Some("Github".to_string()),
         "constantoine@github.com".to_string(),
     )


### PR DESCRIPTION
So that the TOTP struct will securely zero memory when it is dropped.

For this to work I had to remove the generic on the TOTP struct as we need the implementation of `Zeroize` that is declared on `Vec<u8>` when the [zeroize](https://docs.rs/zeroize/latest/zeroize/) library has the `alloc` feature enabled.