### PR TITLE
Relax key length for real world where one cannot chose.

### DIFF
--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -42,7 +42,7 @@ pub fn assert_digits(digits: &usize) -> Result<(), Rfc6238Error> {
 }
 
 pub fn assert_secret_length(secret: &[u8]) -> Result<(), Rfc6238Error> {
-    if secret.as_ref().len() < 16 {
+    if secret.as_ref().len() < 8 {
         Err(Rfc6238Error::SecretTooSmall(secret.as_ref().len() * 8))
     } else {
         Ok(())


### PR DESCRIPTION
Hi, I've integrated totp-rs in pass-fu. Nice and easy. Thanks. Unfortunately I have a system with short keys I have to deal with. This was the minimal change to make it work. The authenticator extension allows it too.

Perhaps you'd like to make it configurable or gate it with a feature flag or just generate a warning, that'd all be fine with me. 

Btw. I did not study much, but glancing over the RFC, I read that the key size should match the HMAC. Haven't found a fixed bit size. Unless indeed the HMAC we use is 16 :)