### PR TITLE
Add Steam algorithm behind 'steam' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ otpauth = ["url", "urlencoding"]
 qr = ["qrcodegen", "image", "base64", "otpauth"]
 serde_support = ["serde"]
 gen_secret = ["rand"]
+steam = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ With optional feature "serde_support", library-defined types `TOTP` and `Algorit
 With optional feature "gen_secret", a secret will be generated for you to store in database.
 ### zeroize
 Securely zero secret information when the TOTP struct is dropped.
+### steam
+Add support for Steam TOTP tokens.
 
 
 # Examples

--- a/src/custom_providers.rs
+++ b/src/custom_providers.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "steam")]
+use crate::{Algorithm, TOTP};
+
+#[cfg(feature = "steam")]
+impl TOTP {
+    #[cfg(feature = "otpauth")]
+    /// Will create a new instance of TOTP using the Steam algorithm with given parameters. See [the doc](struct.TOTP.html#fields) for reference as to how to choose those values
+    ///
+    /// # Description
+    /// * `secret`: expect a non-encoded value, to pass in base32 string use `Secret::Encoded(String)`
+    ///
+    /// ```rust
+    /// use totp_rs::{Secret, TOTP};
+    /// let secret = Secret::Encoded("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".to_string());
+    /// let totp = TOTP::new_steam(secret.to_bytes().unwrap(), Some("username".to_string()));
+    /// ```
+    pub fn new_steam(secret: Vec<u8>, account_name: Option<String>) -> TOTP {
+        Self::new_unchecked(
+            Algorithm::Steam,
+            5,
+            1,
+            30,
+            secret,
+            Some("Steam".into()),
+            account_name
+                .map(|n| format!("Steam:{}", n))
+                .unwrap_or_else(|| "".into()),
+        )
+    }
+
+    #[cfg(not(feature = "otpauth"))]
+    /// Will create a new instance of TOTP using the Steam algorithm with given parameters. See [the doc](struct.TOTP.html#fields) for reference as to how to choose those values
+    ///
+    /// # Description
+    /// * `secret`: expect a non-encoded value, to pass in base32 string use `Secret::Encoded(String)`
+    ///
+    /// ```rust
+    /// use totp_rs::{Secret, TOTP};
+    /// let secret = Secret::Encoded("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".to_string());
+    /// let totp = TOTP::new_steam(secret.to_bytes().unwrap());
+    /// ```
+    pub fn new_steam(secret: Vec<u8>) -> TOTP {
+        Self::new_unchecked(Algorithm::Steam, 5, 1, 30, secret)
+    }
+}

--- a/src/custom_providers.rs
+++ b/src/custom_providers.rs
@@ -14,7 +14,7 @@ impl TOTP {
     /// let secret = Secret::Encoded("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".to_string());
     /// let totp = TOTP::new_steam(secret.to_bytes().unwrap(), Some("username".to_string()));
     /// ```
-    pub fn new_steam(secret: Vec<u8>, account_name: Option<String>) -> TOTP {
+    pub fn new_steam(secret: Vec<u8>, account_name: String) -> TOTP {
         Self::new_unchecked(
             Algorithm::Steam,
             5,
@@ -22,9 +22,7 @@ impl TOTP {
             30,
             secret,
             Some("Steam".into()),
-            account_name
-                .map(|n| format!("Steam:{}", n))
-                .unwrap_or_else(|| "".into()),
+            account_name,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,6 +598,12 @@ impl TOTP {
     /// Secret will be base 32'd without padding, as per RFC.
     #[cfg(feature = "otpauth")]
     pub fn get_url(&self) -> String {
+        #[allow(unused_mut)]
+        let mut host = "totp";
+        #[cfg(feature = "steam")]
+        if self.algorithm == Algorithm::Steam {
+            host = "steam";
+        }
         let account_name: String = urlencoding::encode(self.account_name.as_str()).to_string();
         let mut label: String = format!("{}?", account_name);
         if self.issuer.is_some() {
@@ -607,7 +613,8 @@ impl TOTP {
         }
 
         format!(
-            "otpauth://totp/{}secret={}&digits={}&algorithm={}",
+            "otpauth://{}/{}secret={}&digits={}&algorithm={}",
+            host,
             label,
             self.get_secret_base32(),
             self.digits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,10 @@ impl TOTP {
         match url.host() {
             Some(Host::Domain("totp")) => {}
             #[cfg(feature = "steam")]
-            Some(Host::Domain("steam")) => algorithm = Algorithm::Steam,
+            Some(Host::Domain("steam")) => {
+                algorithm = Algorithm::Steam;
+                digits = 5;
+            }
             _ => {
                 return Err(TotpUrlError::Host(url.host().unwrap().to_string()));
             }
@@ -569,6 +572,12 @@ impl TOTP {
                         value.as_ref(),
                     )
                     .ok_or_else(|| TotpUrlError::Secret(value.to_string()))?;
+                }
+                #[cfg(feature = "steam")]
+                "issuer" if value.to_lowercase() == "steam" => {
+                    algorithm = Algorithm::Steam;
+                    digits = 5;
+                    issuer = Some(value.into());
                 }
                 "issuer" => {
                     let param_issuer = value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 //! # }
 //! ```
 
+mod custom_providers;
 mod rfc;
 mod secret;
 mod url_error;


### PR DESCRIPTION
This implements `Algorithm::Steam` behind the `steam` feature flag.

Fixes https://github.com/constantoine/totp-rs/issues/45

Note that this is somewhat dirty, but keeps the API stability intact. Notably:
- Adds `steam` feature (disabled by default)
- Adds `Algorithm::Steam` variant
- Disables RFC assertions in `TOTP::new()` if algorithm is Steam
- `TOTP::generate()` uses Steam alphabet for token if Steam algorithm is used
- `TOTP::from_url()` parses Steam URLs if the `steam` path is detected.

I've tested this successfully with my personal Steam token. 

I'm not sure if this is good enough to be merged, but I figured this to be a good start.