### PR TITLE
Fix #55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [5.0](https://github.com/constantoine/totp-rs/releases/tag/v4.2) (28/03/2023)
+### Breaking changes.
+- MSRV has been set to Rust `1.61`.
+- Removed `SecretParseError::Utf8Error`.
+
+### Changes
+- Updated `url` to `2.3`.
+- Updated `zeroize` to `1.6`.
+
+### Note
+This major release is a very small one, and is mostly here to respect semver. No major change was done, it is mostly maintenance and cleanup.
+
+### Special thanks
+* [@bestia-dev](https://github.com/bestia-dev) for opening #55.
+
 # [4.2](https://github.com/constantoine/totp-rs/releases/tag/v4.2) (14/01/2023)
 ### Changes
 - Optionnals parameters in generated URLs are no longer present if their're the default value. (#49)
@@ -22,7 +37,7 @@
 - Default features have been set to none.
 
 ### Changes
-- MSRV have been set to Rust `1.59`.
+- MSRV has been set to Rust `1.59`.
 - Updated `base64` crate to `0.20`.
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Removed `SecretParseError::Utf8Error`.
 
 ### Changes
+- Updated `base64` to `0.21`.
 - Updated `url` to `2.3`.
 - Updated `zeroize` to `1.6`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["authentication", "web-programming"]
 features = [ "qr", "serde_support", "gen_secret" ]
 
 [features]
-default = ["qr"]
+default = []
 otpauth = ["url", "urlencoding"]
 qr = ["qrcodegen", "image", "base64", "otpauth"]
 serde_support = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "totp-rs"
-version = "4.2.0"
+version = "5.0.0"
 authors = ["Cleo Rebert <cleo.rebert@gmail.com>"]
-rust-version = "1.59"
+rust-version = "1.61"
 edition = "2021"
 readme = "README.md"
 license = "MIT"
@@ -16,7 +16,7 @@ categories = ["authentication", "web-programming"]
 features = [ "qr", "serde_support", "gen_secret" ]
 
 [features]
-default = []
+default = ["qr"]
 otpauth = ["url", "urlencoding"]
 qr = ["qrcodegen", "image", "base64", "otpauth"]
 serde_support = ["serde"]
@@ -30,10 +30,10 @@ sha1 = "~0.10.5"
 hmac = "~0.12.1"
 base32 = "~0.4"
 urlencoding = { version = "^2.1.0", optional = true}
-url = { version = "^2.2.2", optional = true }
+url = { version = "^2.3.1", optional = true }
 constant_time_eq = "0.2.4"
 qrcodegen = { version = "~1.8", optional = true }
 image = { version = "~0.24.2", features = ["png"], optional = true, default-features = false}
-base64 = { version = "~0.20", optional = true }
+base64 = { version = "~0.21", optional = true }
 rand = { version = "~0.8.5", features = ["std_rng", "std"], optional = true, default-features = false }
-zeroize = { version = "1.5.7", features = ["alloc", "derive"], optional = true }
+zeroize = { version = "1.6.0", features = ["alloc", "derive"], optional = true }

--- a/examples/steam.rs
+++ b/examples/steam.rs
@@ -6,10 +6,7 @@ use totp_rs::{Secret, TOTP};
 fn main() {
     // create TOTP from base32 secret
     let secret_b32 = Secret::Encoded(String::from("OBWGC2LOFVZXI4TJNZTS243FMNZGK5BNGEZDG"));
-    let totp_b32 = TOTP::new_steam(
-        secret_b32.to_bytes().unwrap(),
-        "user-account".to_string(),
-    );
+    let totp_b32 = TOTP::new_steam(secret_b32.to_bytes().unwrap(), "user-account".to_string());
 
     println!(
         "base32 {} ; raw {}",
@@ -41,6 +38,4 @@ fn main() {
 }
 
 #[cfg(not(feature = "steam"))]
-fn main() {
-
-}
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,6 +699,7 @@ impl TOTP {
     #[cfg(feature = "qr")]
     pub fn get_qr(&self) -> Result<String, String> {
         use image::ImageEncoder;
+        use base64::{Engine as _, engine::general_purpose};
 
         let url = self.get_url();
         let mut vec = Vec::new();
@@ -729,7 +730,7 @@ impl TOTP {
             image_size,
             image::ColorType::L8,
         ) {
-            Ok(_) => Ok(base64::encode(vec)),
+            Ok(_) => Ok(general_purpose::STANDARD.encode(vec)),
             Err(err) => Err(err.to_string()),
         }
     }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -78,15 +78,23 @@
 //! ```
 
 use base32::{self, Alphabet};
-use std::string::FromUtf8Error;
 
 use constant_time_eq::constant_time_eq;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SecretParseError {
     ParseBase32,
-    Utf8Error(FromUtf8Error),
 }
+
+impl std::fmt::Display for SecretParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SecretParseError::ParseBase32 => write!(f, "Could not decode base32 secret."),
+        }
+    }
+}
+
+impl std::error::Error for Secret {}
 
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]


### PR DESCRIPTION
### Breaking changes.
- MSRV has been set to Rust `1.61`.
- Removed `SecretParseError::Utf8Error`.

### Changes
- Updated `url` to `2.3`.
- Updated `zeroize` to `1.6`.
