### PR TITLE
Implement Error for SecretParseError

### DIFF
--- a/src/secret.rs
+++ b/src/secret.rs
@@ -88,6 +88,8 @@ pub enum SecretParseError {
     ParseBase32,
 }
 
+impl std::error::Error for SecretParseError {}
+
 impl std::fmt::Display for SecretParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
This makes it easy to use the error with e.g. thiserror or other crates that rely on the trait.