### PR TITLE
Add 'after' parameter to 'check' to ensure that OTP can be used once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,6 +447,7 @@ impl TOTP {
     }
 
     /// Will check if token is valid given the provided timestamp in seconds, accounting [skew](struct.TOTP.html#structfield.skew)
+    /// Optionally, you can specify an 'after' timestamp (in seconds) to prevent token reuse.
     pub fn check(&self, token: &str, time: u64, after: Option<u64>) -> bool {
         let basestep = time / self.step - (self.skew as u64);
 
@@ -467,6 +468,7 @@ impl TOTP {
     }
 
     /// Will check if token is valid by current system time, accounting [skew](struct.TOTP.html#structfield.skew)
+    /// Optionally, you can specify an 'after' timestamp (in seconds) to prevent token reuse.
     pub fn check_current(&self, token: &str, after: Option<u64>) -> Result<bool, SystemTimeError> {
         let t = system_time()?;
         Ok(self.check(token, t, after))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -974,14 +974,14 @@ mod tests {
     #[cfg(not(feature = "otpauth"))]
     fn checks_token() {
         let totp = TOTP::new(Algorithm::SHA1, 6, 0, 1, "TestSecretSuperSecret".into()).unwrap();
-        assert!(totp.check("659761", 1000));
+        assert!(totp.check("659761", 1000, None));
     }
 
     #[test]
     #[cfg(not(feature = "otpauth"))]
     fn checks_token_big_skew() {
         let totp = TOTP::new(Algorithm::SHA1, 6, 255, 1, "TestSecretSuperSecret".into()).unwrap();
-        assert!(totp.check("659761", 1000));
+        assert!(totp.check("659761", 1000, None));
     }
 
     #[test]
@@ -989,9 +989,9 @@ mod tests {
     fn checks_token_current() {
         let totp = TOTP::new(Algorithm::SHA1, 6, 0, 1, "TestSecretSuperSecret".into()).unwrap();
         assert!(totp
-            .check_current(&totp.generate_current().unwrap())
+            .check_current(&totp.generate_current().unwrap(), None)
             .unwrap());
-        assert!(!totp.check_current("bogus").unwrap());
+        assert!(!totp.check_current("bogus", None).unwrap());
     }
 
     #[test]
@@ -999,7 +999,7 @@ mod tests {
     fn checks_token_with_skew() {
         let totp = TOTP::new(Algorithm::SHA1, 6, 1, 1, "TestSecretSuperSecret".into()).unwrap();
         assert!(
-            totp.check("174269", 1000) && totp.check("659761", 1000) && totp.check("260393", 1000)
+            totp.check("174269", 1000, None) && totp.check("659761", 1000, None) && totp.check("260393", 1000, None)
         );
     }
 


### PR DESCRIPTION
@constantoine First and foremost, I would like to thank you for your invaluable work on the totp-rs library. Your efforts are greatly appreciated.

### Problem Statement:
Currently, the totp-rs library generates OTPs based on the TOTP algorithm, but these OTPs can be reused within their time windows. While this is suitable for many scenarios, some applications require stronger security, where OTPs should be valid for a single use only.

### Proposed Solution:
I propose enhancing the totp-rs library's OTP verification mechanism by introducing an `after: Option<u64>` parameter to the `check` function. When users of the library utilize this parameter, it enables them to specify a timestamp or time interval representing the moment after which the OTP should no longer be considered valid.

