### PR TITLE
Add `no_std` Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "totp-rs"
 version = "5.7.1"
 authors = ["Cleo Rebert <cleo.rebert@gmail.com>"]
-rust-version = "1.66"
+rust-version = "1.81"
 edition = "2021"
 readme = "README.md"
 license = "MIT"
@@ -17,22 +17,34 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["std"]
 otpauth = ["url", "urlencoding"]
 qr = ["dep:qrcodegen-image", "otpauth"]
 serde_support = ["serde"]
 gen_secret = ["rand"]
 steam = []
+std = []
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
-sha2 = "0.10"
-sha1 = "0.10"
-hmac = "0.12"
-base32 = "0.5"
-urlencoding = { version = "2.1", optional = true}
-url = { version = "2.4", optional = true }
-constant_time_eq = "0.3"
-rand = { version = "0.9", features = ["thread_rng"], optional = true, default-features = false }
-zeroize = { version = "1.6", features = ["alloc", "derive"], optional = true }
-qrcodegen-image = { version = "1.4", features = ["base64"], optional = true }
+sha2 = { version = "0.10", default-features = false }
+sha1 = { version = "0.10", default-features = false }
+hmac = { version = "0.12", default-features = false }
+base32 = { version = "0.5", default-features = false }
+constant_time_eq = { version = "0.3", default-features = false }
+
+serde = { version = "1.0", features = [
+  "alloc",
+  "derive",
+], optional = true, default-features = false }
+url = { version = "2.4", default-features = false, optional = true }
+urlencoding = { version = "2.1", optional = true, default-features = false }
+rand = { version = "0.9", features = [
+  "thread_rng",
+], optional = true, default-features = false }
+zeroize = { version = "1.6", features = [
+  "alloc",
+  "derive",
+], optional = true, default-features = false }
+qrcodegen-image = { version = "1.4", features = [
+  "base64",
+], optional = true, default-features = false }

--- a/src/custom_providers.rs
+++ b/src/custom_providers.rs
@@ -1,5 +1,11 @@
 #[cfg(feature = "steam")]
-use crate::{Algorithm, TOTP};
+use {
+    crate::{Algorithm, TOTP},
+    alloc::vec::Vec,
+};
+
+#[cfg(all(feature = "steam", feature = "otpauth"))]
+use alloc::string::String;
 
 #[cfg(feature = "steam")]
 #[cfg_attr(docsrs, doc(cfg(feature = "steam")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,12 @@
 
 // enable `doc_cfg` feature for `docs.rs`.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod custom_providers;
 mod rfc;
@@ -62,7 +68,10 @@ pub use rfc::{Rfc6238, Rfc6238Error};
 pub use secret::{Secret, SecretParseError};
 pub use url_error::TotpUrlError;
 
+use alloc::{format, string::String, vec::Vec};
 use constant_time_eq::constant_time_eq;
+use core::fmt;
+use hmac::Mac;
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
@@ -70,12 +79,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "zeroize")]
 use zeroize;
 
-use core::fmt;
-
 #[cfg(feature = "otpauth")]
-use url::{Host, Url};
+use {
+    alloc::{borrow::ToOwned, string::ToString, vec},
+    url::{Host, Url},
+};
 
-use hmac::Mac;
+#[cfg(feature = "std")]
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
 type HmacSha1 = hmac::Hmac<sha1::Sha1>;
@@ -143,6 +153,7 @@ impl Algorithm {
     }
 }
 
+#[cfg(feature = "std")]
 fn system_time() -> Result<u64, SystemTimeError> {
     let t = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
     Ok(t)
@@ -484,18 +495,21 @@ impl TOTP {
 
     /// Returns the timestamp of the first second of the next step
     /// According to system time
+    #[cfg(feature = "std")]
     pub fn next_step_current(&self) -> Result<u64, SystemTimeError> {
         let t = system_time()?;
         Ok(self.next_step(t))
     }
 
     /// Give the ttl (in seconds) of the current token
+    #[cfg(feature = "std")]
     pub fn ttl(&self) -> Result<u64, SystemTimeError> {
         let t = system_time()?;
         Ok(self.step - (t % self.step))
     }
 
     /// Generate a token from the current system time
+    #[cfg(feature = "std")]
     pub fn generate_current(&self) -> Result<String, SystemTimeError> {
         let t = system_time()?;
         Ok(self.generate(t))
@@ -515,6 +529,7 @@ impl TOTP {
     }
 
     /// Will check if token is valid by current system time, accounting [skew](struct.TOTP.html#structfield.skew)
+    #[cfg(feature = "std")]
     pub fn check_current(&self, token: &str) -> Result<bool, SystemTimeError> {
         let t = system_time()?;
         Ok(self.check(token, t))
@@ -684,7 +699,7 @@ impl TOTP {
             digits,
             1,
             step,
-            std::mem::take(&mut secret),
+            core::mem::take(&mut secret),
             issuer,
             account_name,
         ))

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -1,12 +1,14 @@
-use crate::Algorithm;
-use crate::TotpUrlError;
-use crate::TOTP;
+use crate::{Algorithm, TotpUrlError, TOTP};
+use alloc::vec::Vec;
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "zeroize")]
 use zeroize;
+
+#[cfg(feature = "otpauth")]
+use alloc::string::{String, ToString};
 
 /// Error returned when input is not compliant to [rfc-6238](https://tools.ietf.org/html/rfc6238).
 #[derive(Debug, Eq, PartialEq)]
@@ -17,10 +19,10 @@ pub enum Rfc6238Error {
     SecretTooSmall(usize),
 }
 
-impl std::error::Error for Rfc6238Error {}
+impl core::error::Error for Rfc6238Error {}
 
-impl std::fmt::Display for Rfc6238Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Rfc6238Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Rfc6238Error::InvalidDigits(digits) => write!(
                 f,
@@ -118,7 +120,7 @@ impl Rfc6238 {
         let validate = || {
             assert_digits(&digits)?;
             assert_secret_length(secret.as_ref())?;
-    
+
             // NOTE: Unfortunate lack of issuer and account_name checks.
             // Will be fixed in 6.0 cause it would be breaking anyway.
 
@@ -218,7 +220,7 @@ impl TryFrom<Rfc6238> for TOTP {
             rfc.digits,
             rfc.skew,
             rfc.step,
-            std::mem::take(&mut rfc.secret),
+            core::mem::take(&mut rfc.secret),
         )
     }
 }
@@ -234,9 +236,9 @@ impl TryFrom<Rfc6238> for TOTP {
             rfc.digits,
             rfc.skew,
             rfc.step,
-            std::mem::take(&mut rfc.secret),
-            std::mem::take(&mut rfc.issuer),
-            std::mem::take(&mut rfc.account_name),
+            core::mem::take(&mut rfc.secret),
+            core::mem::take(&mut rfc.issuer),
+            core::mem::take(&mut rfc.account_name),
         )
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -77,8 +77,8 @@
 //! # }
 //! ```
 
+use alloc::{string::String, vec::Vec};
 use base32::{self, Alphabet};
-
 use constant_time_eq::constant_time_eq;
 
 /// Different ways secret parsing failed.
@@ -88,17 +88,17 @@ pub enum SecretParseError {
     ParseBase32,
 }
 
-impl std::error::Error for SecretParseError {}
+impl core::error::Error for SecretParseError {}
 
-impl std::fmt::Display for SecretParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SecretParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SecretParseError::ParseBase32 => write!(f, "Could not decode base32 secret."),
         }
     }
 }
 
-impl std::error::Error for Secret {}
+impl core::error::Error for Secret {}
 
 /// Shared secret between client and server to validate token against/generate token from.
 #[derive(Debug, Clone, Eq)]
@@ -178,8 +178,8 @@ impl Secret {
     }
 }
 
-impl std::fmt::Display for Secret {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Secret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Secret::Raw(bytes) => {
                 for b in bytes {
@@ -269,7 +269,7 @@ mod tests {
     #[cfg(feature = "gen_secret")]
     fn secret_empty() {
         let non_ascii = vec![240, 159, 146, 150];
-        let sec = Secret::Encoded(std::str::from_utf8(&non_ascii).unwrap().to_owned());
+        let sec = Secret::Encoded(core::str::from_utf8(&non_ascii).unwrap().to_owned());
 
         let to_r = sec.to_raw();
 

--- a/src/url_error.rs
+++ b/src/url_error.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "otpauth")]
 use url::ParseError;
 
+use alloc::string::String;
+
 use crate::Rfc6238Error;
 
 /// Errors returned mostly upon decoding URL.
@@ -38,10 +40,10 @@ pub enum TotpUrlError {
     AccountNameDecoding(String),
 }
 
-impl std::error::Error for TotpUrlError {}
+impl core::error::Error for TotpUrlError {}
 
-impl std::fmt::Display for TotpUrlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for TotpUrlError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             TotpUrlError::AccountName(name) => write!(
                 f,


### PR DESCRIPTION
# Objective

- Fixes #84

## Solution

- Added `std` feature for `SystemTime`-using APIs and enabled it by default
- Increased MSRV to 1.81 to use `core::error::Error`
- Disabled default features on all dependencies
- Checked with `cargo msrv verify` and `cargo semver-checks` to ensure this is a valid minor patch
- Used `taplo fmt` and `cargo fmt` for style consistency

---

## Notes

- No AI tooling was used in the creation of this PR