### PR TITLE
Add `no_std` Support to `v6`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,15 @@ jobs:
     - name: Build
       run: cargo build --all-features
 
+  build_no_std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install wasm32v1-none Target
+        run: rustup target add wasm32v1-none
+      - name: Build no_std
+        run: cargo build --target wasm32v1-none --no-default-features --features steam,serde_support
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,25 +17,37 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["std"]
 gen_secret = ["rand"]
 otpauth = ["url", "urlencoding"]
 qr = ["dep:qrcodegen-image", "otpauth"]
 serde_support = ["serde", "zeroize?/serde"]
 steam = []
+std = []
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
-sha2 = "0.10"
-sha1 = "0.10"
-hmac = "0.12"
-base32 = "0.5"
-urlencoding = { version = "2.1", optional = true}
-url = { version = "2.4", optional = true }
-constant_time_eq = "0.4"
-rand = { version = "0.10", features = ["thread_rng"], optional = true, default-features = false }
-qrcodegen-image = { version = "1.5", features = ["base64"], optional = true }
-zeroize = { version = "1.8", features = ["alloc", "derive"], optional = true }
+sha2 = { version = "0.10", default-features = false }
+sha1 = { version = "0.10", default-features = false }
+hmac = { version = "0.12", default-features = false }
+base32 = { version = "0.5", default-features = false }
+constant_time_eq = { version = "0.4", default-features = false }
+
+serde = { version = "1.0", features = [
+  "alloc",
+  "derive",
+], optional = true, default-features = false }
+url = { version = "2.4", default-features = false, optional = true }
+urlencoding = { version = "2.1", optional = true, default-features = false }
+rand = { version = "0.10", features = [
+  "thread_rng",
+], optional = true, default-features = false }
+zeroize = { version = "1.8", features = [
+  "alloc",
+  "derive",
+], optional = true, default-features = false }
+qrcodegen-image = { version = "1.5", features = [
+  "base64",
+], optional = true, default-features = false }
 
 [[example]]
 name = "steam"

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,14 +1,20 @@
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::error::Error;
+use core::fmt;
+use core::str::FromStr;
 use hmac::Mac;
-type HmacSha1 = hmac::Hmac<sha1::Sha1>;
-type HmacSha256 = hmac::Hmac<sha2::Sha256>;
-type HmacSha512 = hmac::Hmac<sha2::Sha512>;
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
-use std::error::Error;
-use std::fmt;
-use std::str::FromStr;
+type HmacSha1 = hmac::Hmac<sha1::Sha1>;
+type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+type HmacSha512 = hmac::Hmac<sha2::Sha512>;
 
 /// Alphabet for Steam tokens.
 #[cfg(feature = "steam")]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,13 @@
 use crate::error::TotpError;
 use crate::secret::InnerSecret;
 use crate::{Algorithm, Totp};
+use alloc::vec::Vec;
+
+#[cfg(feature = "otpauth")]
+use alloc::string::{String, ToString};
+
+#[cfg(feature = "gen_secret")]
+use alloc::vec;
 
 /// Builder used to build a [Totp] with sane defaults.
 /// Because it contains the sensitive data of the HMAC secret, treat it accordingly.
@@ -33,7 +40,6 @@ impl Builder {
             let mut secret: InnerSecret = vec![0; 20].into();
             rng.fill(&mut secret[..]);
 
-            #[cfg(feature = "gen_secret")]
             Some(secret)
         };
 
@@ -43,7 +49,7 @@ impl Builder {
         Builder {
             algorithm: Algorithm::SHA1,
             digits: 6,
-            secret: std::mem::take(&mut secret),
+            secret: core::mem::take(&mut secret),
             skew: 1,
             step_duration: 30,
             #[cfg(feature = "otpauth")]
@@ -195,12 +201,12 @@ impl Builder {
             digits: self.digits,
             skew: self.skew,
             step: self.step_duration,
-            secret: std::mem::take(&mut self.secret).unwrap_or_default(),
+            secret: core::mem::take(&mut self.secret).unwrap_or_default(),
 
             #[cfg(feature = "otpauth")]
-            issuer: std::mem::take(&mut self.issuer),
+            issuer: core::mem::take(&mut self.issuer),
             #[cfg(feature = "otpauth")]
-            account_name: std::mem::take(&mut self.account_name),
+            account_name: core::mem::take(&mut self.account_name),
         }
     }
 }
@@ -269,7 +275,7 @@ mod tests {
         let to_compare: InnerSecret = GOOD_SECRET.as_bytes().to_vec().into();
 
         assert_eq!(
-            std::mem::take(&mut builder.secret.clone().unwrap()),
+            core::mem::take(&mut builder.secret.clone().unwrap()),
             to_compare
         );
     }

--- a/src/custom_providers.rs
+++ b/src/custom_providers.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "steam")]
 use crate::{Algorithm, Builder};
 
+#[cfg(all(feature = "steam", feature = "otpauth"))]
+use alloc::string::ToString;
+
 #[cfg(feature = "steam")]
 #[cfg_attr(docsrs, doc(cfg(feature = "steam")))]
 impl Builder {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "otpauth")]
-use url::ParseError;
+use {alloc::string::String, url::ParseError};
 
 #[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -55,8 +55,8 @@ pub enum TotpError {
     IssuerMismatch { path: String, query: String },
 }
 
-impl std::fmt::Display for TotpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for TotpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             TotpError::SecretTooShort { bits } => write!(
                 f,
@@ -123,8 +123,8 @@ impl std::fmt::Display for TotpError {
     }
 }
 
-impl std::error::Error for TotpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for TotpError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             #[cfg(feature = "otpauth")]
             TotpError::UrlParse(e) => Some(e),
@@ -309,7 +309,7 @@ mod test {
 
     #[test]
     fn error_source_none() {
-        use std::error::Error;
+        use core::error::Error;
 
         let error = TotpError::SecretTooShort { bits: 64 };
         assert!(error.source().is_none());
@@ -324,7 +324,7 @@ mod test {
     #[test]
     #[cfg(feature = "otpauth")]
     fn error_source_url_parse() {
-        use std::error::Error;
+        use core::error::Error;
 
         let parse_error = url::ParseError::EmptyHost;
         let error = TotpError::UrlParse(parse_error);
@@ -336,7 +336,7 @@ mod test {
     #[test]
     #[cfg(feature = "otpauth")]
     fn error_source_none_otpauth_variants() {
-        use std::error::Error;
+        use core::error::Error;
 
         let error = TotpError::InvalidAlgorithm {
             algorithm: "MD5".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,13 @@
 
 // enable `doc_cfg` feature for `docs.rs`.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Only allow implicit `use std::prelude::*;` during testing.
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod algorithm;
 mod builder;
@@ -83,15 +90,20 @@ pub use builder::Builder;
 pub use error::TotpError;
 pub use secret::{Secret, SecretParseError};
 
+use alloc::{format, string::String, vec::Vec};
 use constant_time_eq::constant_time_eq;
+use core::fmt;
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
-use core::fmt;
+#[cfg(feature = "otpauth")]
+use alloc::string::ToString;
 
+#[cfg(feature = "std")]
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
+#[cfg(feature = "std")]
 fn system_time() -> Result<u64, SystemTimeError> {
     let t = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
     Ok(t)
@@ -219,18 +231,21 @@ impl Totp {
 
     /// Returns the timestamp of the first second of the next step
     /// According to system time
+    #[cfg(feature = "std")]
     pub fn next_step_current(&self) -> Result<u64, SystemTimeError> {
         let t = system_time()?;
         Ok(self.next_step(t))
     }
 
     /// Give the ttl (in seconds) of the current token
+    #[cfg(feature = "std")]
     pub fn ttl(&self) -> Result<u64, SystemTimeError> {
         let t = system_time()?;
         Ok(self.step - (t % self.step))
     }
 
     /// Generate a token from the current system time
+    #[cfg(feature = "std")]
     pub fn generate_current(&self) -> Result<String, SystemTimeError> {
         let t = system_time()?;
         Ok(self.generate(t))
@@ -250,6 +265,7 @@ impl Totp {
     }
 
     /// Will check if token is valid by current system time, accounting [skew](struct.Totp.html#structfield.skew)
+    #[cfg(feature = "std")]
     pub fn check_current(&self, token: &str) -> Result<bool, SystemTimeError> {
         let t = system_time()?;
         Ok(self.check(token, t))
@@ -257,7 +273,7 @@ impl Totp {
 
     /// Will return a clone of the secret as raw bytes.
     pub fn to_secret_binary(&self) -> Vec<u8> {
-        std::mem::take(&mut self.secret.clone())
+        core::mem::take(&mut self.secret.clone())
     }
 
     /// Will return the base32 representation of the secret, which might be useful when users want to manually add the secret to their authenticator

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -1,5 +1,8 @@
 use crate::TotpError;
 
+#[cfg(feature = "otpauth")]
+use alloc::string::String;
+
 // Check that the number of digits is RFC-compliant.
 // (between 6 and 8 inclusive).
 pub fn assert_digits(digits: u32) -> Result<(), TotpError> {

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -65,8 +65,8 @@
 //! # }
 //! ```
 
+use alloc::{string::String, vec::Vec};
 use base32::{self, Alphabet};
-
 use constant_time_eq::constant_time_eq;
 
 /// Different ways secret parsing failed.
@@ -81,17 +81,17 @@ pub(crate) type InnerSecret = Vec<u8>;
 #[cfg(feature = "zeroize")]
 pub(crate) type InnerSecret = zeroize::Zeroizing<Vec<u8>>;
 
-impl std::error::Error for SecretParseError {}
+impl core::error::Error for SecretParseError {}
 
-impl std::fmt::Display for SecretParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SecretParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SecretParseError::ParseBase32 => write!(f, "Could not decode base32 secret."),
         }
     }
 }
 
-impl std::error::Error for Secret {}
+impl core::error::Error for Secret {}
 
 /// Shared secret between client and server to validate token against/generate token from.
 #[derive(Debug, Clone, Eq)]
@@ -171,8 +171,8 @@ impl Secret {
     }
 }
 
-impl std::fmt::Display for Secret {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Secret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Secret::Raw(bytes) => {
                 for b in bytes {
@@ -262,7 +262,7 @@ mod tests {
     #[cfg(feature = "gen_secret")]
     fn secret_empty() {
         let non_ascii = vec![240, 159, 146, 150];
-        let sec = Secret::Encoded(std::str::from_utf8(&non_ascii).unwrap().to_owned());
+        let sec = Secret::Encoded(core::str::from_utf8(&non_ascii).unwrap().to_owned());
 
         let to_r = sec.to_raw();
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,5 +1,10 @@
 use crate::{Algorithm, Builder, Totp, TotpError};
-
+use alloc::{
+    borrow::ToOwned,
+    format,
+    string::{String, ToString},
+    vec,
+};
 use url::{Host, Url};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "otpauth")))]


### PR DESCRIPTION
# Objective

- Fixes #84

## Solution

- Added `std` feature for `SystemTime`-using APIs and enabled it by default
- Disabled default features on all dependencies
- Used `taplo fmt` and `cargo fmt` for style consistency
- Added `build_no_std` CI task to ensure `no_std` compatibility doesn't regress

---

## Notes

- No AI tooling was used in the creation of this PR
- See #86 for further comments