### PR TITLE
Additional `no_std` Support in `v6`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install wasm32v1-none Target
         run: rustup target add wasm32v1-none
       - name: Build no_std
-        run: cargo build --target wasm32v1-none --no-default-features --features steam,serde_support
+        run: RUSTFLAGS='--cfg getrandom_backend="unsupported"' cargo build --target wasm32v1-none --no-default-features --features steam,serde,otpauth,gen_secret,zeroize
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["std"]
-gen_secret = ["rand"]
-otpauth = ["url", "urlencoding"]
+gen_secret = ["dep:rand"]
+otpauth = ["dep:url", "dep:percent-encoding"]
 qr = ["dep:qrcodegen-image", "otpauth"]
-serde_support = ["serde", "zeroize?/serde"]
+serde = ["dep:serde", "zeroize?/serde"]
 steam = []
-std = []
+std = ["rand?/thread_rng"]
+zeroize = ["dep:zeroize"]
 
 [dependencies]
 sha2 = { version = "0.10", default-features = false }
@@ -37,9 +38,12 @@ serde = { version = "1.0", features = [
   "derive",
 ], optional = true, default-features = false }
 url = { version = "2.4", default-features = false, optional = true }
-urlencoding = { version = "2.1", optional = true, default-features = false }
+percent-encoding = { version = "2.3.2", features = [
+  "alloc",
+], default-features = false, optional = true }
 rand = { version = "0.10", features = [
-  "thread_rng",
+  "sys_rng",
+  "chacha",
 ], optional = true, default-features = false }
 zeroize = { version = "1.8", features = [
   "alloc",

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ With optional feature "qr", you can use it to generate a base64 png qrcode. This
 
 With optional feature "otpauth", support parsing the TOTP parameters from an `otpauth` URL, and generating an `otpauth` URL. It adds 2 fields to `Totp`.
 
-### serde_support
+### serde
 
-With optional feature "serde_support", library-defined types `Totp` and `Algorithm` and will be Deserialize-able and Serialize-able.
+With optional feature "serde", library-defined types `Totp` and `Algorithm` and will be Deserialize-able and Serialize-able.
 
 ### gen_secret
 
@@ -152,7 +152,7 @@ Add it to your `Cargo.toml`:
 ```toml
 [dependencies.totp-rs]
 version = "^5.0"
-features = ["serde_support"]
+features = ["serde"]
 ```
 
 ### With otpauth url support

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use core::str::FromStr;
 use hmac::Mac;
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 type HmacSha1 = hmac::Hmac<sha1::Sha1>;
@@ -22,8 +22,8 @@ pub(super) const STEAM_CHARS: &str = "23456789BCDFGHJKMNPQRTVWXY";
 
 /// Algorithm enum holds the three standards algorithms for TOTP as per the [reference implementation](https://tools.ietf.org/html/rfc6238#appendix-A)
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde_support", serde(try_from = "String", into = "String"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
 pub enum Algorithm {
     /// HMAC-SHA1 is the default algorithm of most TOTP implementations.
     /// Some will outright silently ignore the algorithm parameter to force using SHA1, leading to confusion.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,9 +6,6 @@ use alloc::vec::Vec;
 #[cfg(feature = "otpauth")]
 use alloc::string::{String, ToString};
 
-#[cfg(feature = "gen_secret")]
-use alloc::vec;
-
 /// Builder used to build a [Totp] with sane defaults.
 /// Because it contains the sensitive data of the HMAC secret, treat it accordingly.
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
@@ -33,15 +30,7 @@ impl Builder {
     /// After build, use [Totp::to_secret_binary] or [Totp::to_secret_base32] to retrieve the newly generated secret.
     pub fn new() -> Self {
         #[cfg(feature = "gen_secret")]
-        let mut secret = {
-            use rand::prelude::*;
-
-            let mut rng = rand::rng();
-            let mut secret: InnerSecret = vec![0; 20].into();
-            rng.fill(&mut secret[..]);
-
-            Some(secret)
-        };
+        let mut secret = Some(Vec::from(crate::secret::generate_random_bytes()).into());
 
         #[cfg(not(feature = "gen_secret"))]
         let mut secret = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use alloc::{format, string::String, vec::Vec};
 use constant_time_eq::constant_time_eq;
 use core::fmt;
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "otpauth")]
@@ -111,7 +111,7 @@ fn system_time() -> Result<u64, SystemTimeError> {
 
 /// TOTP holds informations as to how to generate an auth code and validate it. Its [secret](struct.Totp.html#structfield.secret) field is sensitive data, treat it accordingly
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct Totp {
     /// SHA-1 is the most widespread algorithm used, and for totp pursposes, SHA-1 hash collisions are [not a problem](https://tools.ietf.org/html/rfc4226#appendix-B.2) as HMAC-SHA-1 is not impacted. It's also the main one cited in [rfc-6238](https://tools.ietf.org/html/rfc6238#section-3) even though the [reference implementation](https://tools.ietf.org/html/rfc6238#appendix-A) permits the use of SHA-1, SHA-256 and SHA-512. Not all clients support other algorithms then SHA-1

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -162,12 +162,7 @@ impl Secret {
     #[cfg(feature = "gen_secret")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gen_secret")))]
     pub fn generate_secret() -> Secret {
-        use rand::prelude::*;
-
-        let mut rng = rand::rng();
-        let mut secret: [u8; 20] = Default::default();
-        rng.fill(&mut secret[..]);
-        Secret::Raw(secret.to_vec())
+        Secret::Raw(generate_random_bytes().to_vec())
     }
 }
 
@@ -183,6 +178,25 @@ impl core::fmt::Display for Secret {
             Secret::Encoded(s) => write!(f, "{}", s),
         }
     }
+}
+
+#[cfg(feature = "gen_secret")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gen_secret")))]
+pub(crate) fn generate_random_bytes() -> [u8; 20] {
+    use rand::RngExt as _;
+
+    // Attempt to use the thread-local CSPRNG from rand::rng() if `std` is enabled.
+    // Otherwise, fallback to creating the same CSPRNG ourselves.
+    // Cryptographically, these are equally secure, enabling `std` just allows
+    // for potentially better performance, as seeding ChaCha12Rng has some initialisation cost.
+    #[cfg(feature = "std")]
+    let mut rng = rand::rng();
+    #[cfg(not(feature = "std"))]
+    let mut rng = rand::make_rng::<rand::rngs::ChaCha12Rng>();
+
+    let mut secret = [0u8; _];
+    rng.fill(&mut secret[..]);
+    secret
 }
 
 #[cfg(test)]

--- a/src/url.rs
+++ b/src/url.rs
@@ -48,8 +48,8 @@ impl crate::Totp {
         builder.secret = None;
 
         let path = url.path().trim_start_matches('/');
-        let path = urlencoding::decode(path)
-            .map_err(|_| TotpError::AccountNameDecode {
+        let path = percent_decode(path)
+            .ok_or_else(|| TotpError::AccountNameDecode {
                 value: path.to_string(),
             })?
             .to_string();
@@ -65,8 +65,8 @@ impl crate::Totp {
             account_name = path;
         }
 
-        let account_name = urlencoding::decode(account_name.as_str())
-            .map_err(|_| TotpError::AccountNameDecode {
+        let account_name = percent_decode(account_name.as_str())
+            .ok_or_else(|| TotpError::AccountNameDecode {
                 value: account_name.to_string(),
             })?
             .to_string();
@@ -165,7 +165,7 @@ impl crate::Totp {
         if self.algorithm == Algorithm::Steam {
             host = "steam";
         }
-        let account_name = urlencoding::encode(self.account_name.as_str()).to_string();
+        let account_name = percent_encode(self.account_name.as_str()).to_string();
         let mut params = vec![format!("secret={}", self.to_secret_base32())];
         if self.digits != 6 {
             params.push(format!("digits={}", self.digits));
@@ -174,7 +174,7 @@ impl crate::Totp {
             params.push(format!("algorithm={}", self.algorithm));
         }
         let label = if let Some(issuer) = &self.issuer {
-            let issuer = urlencoding::encode(issuer);
+            let issuer = percent_encode(issuer);
             params.push(format!("issuer={}", issuer));
             format!("{}:{}", issuer, account_name)
         } else {
@@ -186,6 +186,24 @@ impl crate::Totp {
 
         format!("otpauth://{}/{}?{}", host, label, params.join("&"))
     }
+}
+
+fn percent_decode(input: &str) -> Option<impl core::fmt::Display + Clone + '_> {
+    let decoded = percent_encoding::percent_decode_str(input)
+        .decode_utf8()
+        .ok()?;
+
+    Some(decoded)
+}
+
+fn percent_encode(input: &str) -> impl core::fmt::Display + Clone + '_ {
+    const URL_INCOMPATIBLE: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'_')
+        .remove(b'.')
+        .remove(b'~');
+
+    percent_encoding::utf8_percent_encode(input, URL_INCOMPATIBLE)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

- Extends #87 by allowing more features in `no_std` contexts

## Solution

- Renamed `serde_support` feature to `serde` (for consistency with other Rust crates).
- Switched optional dependencies to `dep:X` syntax in features to prevent implicit optional features being created (v5 has malformed features `serde`, `url`, `urlencoding`, and `rand`).
- Added explicit `zeroize` feature rather than replying on implicit feature created by optional an dependency.
- Replaced `urlencoding` with `percent-encoding` from the Servo project. It's more commonly used and has `no_std` support, allowing the `otpauth` feature to work in `no_std`.
- Adjusted `rand`'s features to only enable `thread_rng` when `std` is enabled, and instead rely on `sys_rng` and `chacha` for a default implementation of `gen_secret`. Note that `sys_rng` and `chacha` are enabled by `thread_rng` so no new features are enabled. This allows `gen_secret` to work in `no_std`, provided the user has correctly setup `getrandom` or their platform is natively supported.
- Updated `Build no_std` CI task to test newly `no_std` compatible features

---

## Notes

- No AI tooling was used in the creation of this PR
- Creating as a draft as this branch is based on #87, and should not be merged until it is.