### PR TITLE
Change algorithm matching to use uppercase values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ impl TOTP {
                     // Do not change used algorithm if this is Steam
                 }
                 "algorithm" => {
-                    algorithm = match value.as_ref() {
+                    algorithm = match value.to_uppercase().as_ref() {
                         "SHA1" => Algorithm::SHA1,
                         "SHA256" => Algorithm::SHA256,
                         "SHA512" => Algorithm::SHA512,


### PR DESCRIPTION
Since some otpauth urls are created by using lowercase "algorithm", this makes it possible to parse them correctly. This is not strictly RFC compliant, as only uppercase SHA strings are considered in the RFC, but some services do issue otpauth urls with lowercase "algorithm" and most validators still work.